### PR TITLE
Feature/83 feedback for managers que

### DIFF
--- a/wman-backend/Wman.Logic/Classes/StatsLogic.cs
+++ b/wman-backend/Wman.Logic/Classes/StatsLogic.cs
@@ -123,8 +123,8 @@ namespace Wman.Logic.Classes
             if (!int.TryParse(input, out _) || int.Parse(input) > 31) //No valid config value, use defaults
             {
                 RecurringJob.RemoveIfExists("scheduledXlsReport");
-                RecurringJob.AddOrUpdate("defaultCaseXls", () => this.GetStats(DateTime.Now.AddDays(-2)), Cron.Monthly); //No schedule provided, default is sending the prev. month's stats on the first day of current month
-                Debug.WriteLine("\n--- No valid \"xlsSchedule\" tag found in appsettings.json, using defaults (1st day of each month)!--- ");
+                RecurringJob.AddOrUpdate("defaultCaseXls", () => this.GetStats(DateTime.Now.AddDays(-2)), Cron.Monthly, TimeZoneInfo.Local); //No schedule provided, default is sending the prev. month's stats on the first day of current month
+                Debug.WriteLine("\n--- No valid \"xlsSchedule\" tag found in appsettings.json, using defaults (1st day of each month)!--- \n");
             }
             else if (int.Parse(input) <= 0) // 0 or less value, disable scheduled emails
             {
@@ -135,7 +135,7 @@ namespace Wman.Logic.Classes
             else //Valid value, schedule based on input (Every x days counting from the first of month)
             {
                 var cronExpr = $"0 12 1/{input} * *";
-                RecurringJob.AddOrUpdate("scheduledXlsReport", () => this.GetStats(DateTime.Now), cronExpr);
+                RecurringJob.AddOrUpdate("scheduledXlsReport", () => this.GetStats(DateTime.Now), cronExpr, TimeZoneInfo.Local);
                 RecurringJob.RemoveIfExists("defaultCaseXls");
 
                 Debug.WriteLine($"\n--- Scheduled xls generation&sending every {input} days (From the beginning of the month)!--- \n");

--- a/wman-backend/Wman.Logic/Classes/StatsLogic.cs
+++ b/wman-backend/Wman.Logic/Classes/StatsLogic.cs
@@ -1,9 +1,11 @@
 ﻿using ClosedXML.Excel;
+using Hangfire;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -114,6 +116,22 @@ namespace Wman.Logic.Classes
             foreach (var item in managers)
             {
                 await emailService.SendXls(item, fileName);
+            }
+        }
+        public async void registerRecurringJob(string x)
+        {
+            if (!string.IsNullOrWhiteSpace(x))
+            {
+                var cronExpr = "0 12 1/INPUTVALUE * *";
+                cronExpr = cronExpr.Replace("INPUTVALUE", x);
+                RecurringJob.AddOrUpdate("scheduledXlsReport", () => this.GetStats(DateTime.Now), cronExpr);
+                Debug.WriteLine($"\n--- Scheduled xls generation&sending every {x} days starting from the 1st of the month!--- \n");
+            }
+            else
+            {
+                RecurringJob.RemoveIfExists("scheduledXlsReport");
+                Debug.WriteLine("\n--- No \"xlsSchedule\" tag found in appsettings.json, scheduled xls sending is disabled!--- ");
+                Debug.WriteLine("Valid example: \"xlsSchedule\": \"5\"\n");
             }
         }
         private string GetFilename()

--- a/wman-backend/Wman.Logic/Classes/StatsLogic.cs
+++ b/wman-backend/Wman.Logic/Classes/StatsLogic.cs
@@ -125,6 +125,7 @@ namespace Wman.Logic.Classes
                 var cronExpr = "0 12 1/INPUTVALUE * *";
                 cronExpr = cronExpr.Replace("INPUTVALUE", x);
                 RecurringJob.AddOrUpdate("scheduledXlsReport", () => this.GetStats(DateTime.Now), cronExpr);
+                await fileRepo.DeleteOldFiles(this.GetPath(), ".xlsx", DateTime.Now.AddMonths(-1)); //Delete every .xlsx file older than a month
                 Debug.WriteLine($"\n--- Scheduled xls generation&sending every {x} days starting from the 1st of the month!--- \n");
             }
             else

--- a/wman-backend/Wman.Logic/Interfaces/IStatsLogic.cs
+++ b/wman-backend/Wman.Logic/Interfaces/IStatsLogic.cs
@@ -12,5 +12,6 @@ namespace Wman.Logic.Interfaces
     {
         Task<ICollection<StatsXlsModel>> GetStats(DateTime month);
         Task SendEmails(string username);
+        void registerRecurringJob(string x);
     }
 }

--- a/wman-backend/Wman.Logic/Wman.Logic.csproj
+++ b/wman-backend/Wman.Logic/Wman.Logic.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
     <PackageReference Include="ClosedXML" Version="0.95.4" />
     <PackageReference Include="CloudinaryDotNet" Version="1.15.2" />
+    <PackageReference Include="Hangfire.Core" Version="1.7.28" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Core" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />

--- a/wman-backend/Wman.Repository/Classes/FileRepo.cs
+++ b/wman-backend/Wman.Repository/Classes/FileRepo.cs
@@ -23,5 +23,16 @@ namespace Wman.Repository.Classes
         {
             return new DirectoryInfo(path);
         }
+        public async Task DeleteOldFiles(string path, string extension, DateTime olderThan)
+        {
+            var files = Directory.GetFiles(path).Where(x => x.ToLower().EndsWith(extension.ToLower()));
+
+            foreach (string file in files)
+            {
+                FileInfo fi = new FileInfo(file);
+                if (fi.CreationTime < olderThan)
+                    fi.Delete();
+            }
+        }
     }
 }

--- a/wman-backend/Wman.Repository/Interfaces/IFileRepo.cs
+++ b/wman-backend/Wman.Repository/Interfaces/IFileRepo.cs
@@ -11,5 +11,6 @@ namespace Wman.Repository.Interfaces
     {
         Task Create(string path, Stream stream);
         Task<DirectoryInfo> GetDetails(string path);
+        Task DeleteOldFiles(string path, string extension, DateTime olderThan);
     }
 }

--- a/wman-backend/Wman.WebAPI/Controllers/ManagerController.cs
+++ b/wman-backend/Wman.WebAPI/Controllers/ManagerController.cs
@@ -14,7 +14,7 @@ namespace Wman.WebAPI.Controllers
     /// </summary>
     [Route("[controller]")]
     [ApiController]
-    [Authorize(Roles = "Manager")]
+    [Authorize(Roles = "Manager, Admin")]
     public class ManagerController : ControllerBase
     {
         IEventLogic eventLogic;
@@ -31,10 +31,11 @@ namespace Wman.WebAPI.Controllers
 
         }
         /// <summary>
-        /// Endpoint to test the output of the upcoming xls export. Will be removed once excel exporting is implemented
+        /// Testing endpoint to test the output of the xls export.
         /// </summary>
         /// <returns></returns>
         /// 
+        [Authorize(Roles = "Admin")]
         [HttpGet("GenerateXls")]
         public async Task<ActionResult> StatsThisMonth()
         {
@@ -42,11 +43,12 @@ namespace Wman.WebAPI.Controllers
         }
 
         /// <summary>
-        /// Endpoint used for sending the xls stats to all the managers. 
+        /// Testing endpoint used for sending the xls stats to all the managers. 
         /// </summary>
         /// <param name="filename">Name of the .xlsx. If left empty, the latest one is used</param>
         /// <returns></returns>
-        [HttpGet("sendemails")]
+        [HttpGet("Sendemails")]
+        [Authorize(Roles = "Admin")]
         public async Task<ActionResult> SendEmails(string filename)
             {
             await this.statsLogic.SendEmails(filename);

--- a/wman-backend/Wman.WebAPI/Startup.cs
+++ b/wman-backend/Wman.WebAPI/Startup.cs
@@ -1,3 +1,5 @@
+using Hangfire;
+using Hangfire.SqlServer;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -15,6 +17,7 @@ using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -186,16 +189,31 @@ namespace Wman.WebAPI
 
             services.AddAutoMapper(typeof(AutoMapperProfiles).Assembly);
             services.AddSignalR();
+            services.AddHangfire(configuration => configuration
+        .SetDataCompatibilityLevel(CompatibilityLevel.Version_170)
+        .UseSimpleAssemblyNameTypeSerializer()
+        .UseRecommendedSerializerSettings()
+        .UseSqlServerStorage(Configuration.GetConnectionString("wmandb"), new SqlServerStorageOptions
+        {
+            CommandBatchMaxTimeout = TimeSpan.FromMinutes(5),
+            SlidingInvisibilityTimeout = TimeSpan.FromMinutes(5),
+            QueuePollInterval = TimeSpan.Zero,
+            UseRecommendedIsolationLevel = true,
+            DisableGlobalLocks = true
+        }));
 
+            // Add the processing server as IHostedService
+            services.AddHangfireServer();
         }
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, IStatsLogic statsLogic)
         {
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
 
             }
+            app.UseHangfireDashboard();
             app.UseSwagger();
             //app.UseStatusCodePages();
             app.UseSwaggerUI(c =>
@@ -214,11 +232,13 @@ namespace Wman.WebAPI
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllers();
+                endpoints.MapHangfireDashboard();
                 endpoints.MapHub<NotifyHub>("/notify", opt =>
                 {
 
                 });
-            });
+            });   
+            statsLogic.registerRecurringJob(Configuration.GetValue<string>("xlsSchedule"));
         }
 
         static string XmlCommentsFilePath

--- a/wman-backend/Wman.WebAPI/Startup.cs
+++ b/wman-backend/Wman.WebAPI/Startup.cs
@@ -79,7 +79,7 @@ namespace Wman.WebAPI
             services.AddTransient<IFileRepo, FileRepo>();
             services.AddTransient<IPhotoService, PhotoService>();
             services.AddTransient<IEmailService, EmailService>();
-            
+
             services.AddSwaggerGen(c =>
             {
                 //c.DescribeAllEnumsAsStrings();
@@ -202,9 +202,9 @@ namespace Wman.WebAPI
             DisableGlobalLocks = true
         }));
 
-            // Add the processing server as IHostedService
             services.AddHangfireServer();
         }
+
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, IStatsLogic statsLogic)
         {
@@ -213,7 +213,9 @@ namespace Wman.WebAPI
                 app.UseDeveloperExceptionPage();
 
             }
+#if DEBUG
             app.UseHangfireDashboard();
+#endif
             app.UseSwagger();
             //app.UseStatusCodePages();
             app.UseSwaggerUI(c =>
@@ -232,12 +234,14 @@ namespace Wman.WebAPI
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllers();
+#if DEBUG
                 endpoints.MapHangfireDashboard();
+#endif
                 endpoints.MapHub<NotifyHub>("/notify", opt =>
                 {
 
                 });
-            });   
+            });
             statsLogic.registerRecurringJob(Configuration.GetValue<string>("xlsSchedule"));
         }
 

--- a/wman-backend/Wman.WebAPI/Wman.WebAPI.csproj
+++ b/wman-backend/Wman.WebAPI/Wman.WebAPI.csproj
@@ -14,6 +14,9 @@
 
   <ItemGroup>
     <PackageReference Include="CloudinaryDotNet" Version="1.15.2" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.28" />
+    <PackageReference Include="Hangfire.Core" Version="1.7.28" />
+    <PackageReference Include="Hangfire.SqlServer" Version="1.7.28" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.10">
       <PrivateAssets>all</PrivateAssets>

--- a/wman-backend/Wman.WebAPI/Wman.WebAPI.xml
+++ b/wman-backend/Wman.WebAPI/Wman.WebAPI.xml
@@ -192,7 +192,7 @@
         </member>
         <member name="M:Wman.WebAPI.Controllers.ManagerController.StatsThisMonth">
             <summary>
-            Testing endpoint to test the output of the upcoming xls export.
+            Testing endpoint to test the output of the xls export.
             </summary>
             <returns></returns>
             

--- a/wman-backend/Wman.WebAPI/Wman.WebAPI.xml
+++ b/wman-backend/Wman.WebAPI/Wman.WebAPI.xml
@@ -192,14 +192,14 @@
         </member>
         <member name="M:Wman.WebAPI.Controllers.ManagerController.StatsThisMonth">
             <summary>
-            Endpoint to test the output of the upcoming xls export. Will be removed once excel exporting is implemented
+            Testing endpoint to test the output of the upcoming xls export.
             </summary>
             <returns></returns>
             
         </member>
         <member name="M:Wman.WebAPI.Controllers.ManagerController.SendEmails(System.String)">
             <summary>
-            Endpoint used for sending the xls stats to all the managers. 
+            Testing endpoint used for sending the xls stats to all the managers. 
             </summary>
             <param name="filename">Name of the .xlsx. If left empty, the latest one is used</param>
             <returns></returns>


### PR DESCRIPTION
The `"xlsSchedule": "3"` tag in `appsettings.json` controls the email sending schedule.
If not present, emails are sent on the first day of each month
If set to <= 0, scheduled email sending is disabled
Otherwise, emails are sent every `x` days, counting from the first of each month. (Every 3rd day in the above example)

Currently scheduled tasks can be viewed at: https://localhost:44371/hangfire/recurring